### PR TITLE
Add metadata info

### DIFF
--- a/clean.sh
+++ b/clean.sh
@@ -1,2 +1,3 @@
 rm -r bin
 rm -f package.json
+rm -f .piopm

--- a/init.sh
+++ b/init.sh
@@ -27,3 +27,15 @@ cat <<__EOF__ >package.json
     "version": "${VERSION}"
 }
 __EOF__
+
+cat <<__EOF__ >.piopm
+{
+    "name": "tool-esptool",
+    "type": "tool",
+    "spec": {
+        "name": "tool-esptool",
+        "owner": "platformio"
+    },
+    "version": "${VERSION}"
+}
+__EOF__


### PR DESCRIPTION
Since platformio introduced "owner" requirements for dependencies, we need another magic file.

See [v5.0.1 release notes](https://github.com/platformio/platformio-core/blob/develop/HISTORY.rst#501-2020-09-10) for details.